### PR TITLE
Report errors mapping amino acids

### DIFF
--- a/main.c
+++ b/main.c
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
 	for (i = o.ind + 1; i < argc; ++i) {
 		int32_t res = mp_map_file(mi, argv[i], &mo, n_threads);
 		if (res != 0) {
-			fprintf(stderr, "[M::%s] ERROR during mapping %s (check files exists and is amino acid fasta)\n", __func__, argv[i]);
+			fprintf(stderr, "[M::%s] ERROR during mapping %s (check files exists and are amino acid fastas)\n", __func__, argv[i]);
 			return 1;
 		}
 	}

--- a/main.c
+++ b/main.c
@@ -175,8 +175,13 @@ int main(int argc, char *argv[])
 	if (set_I && !set_G) mp_mapopt_set_max_intron(&mo, mi->nt->l_seq);
 	if (mp_verbose >= 3) mp_idx_print_stat(mi, mo.max_occ);
 	if (fn_idx != 0) mp_idx_dump(fn_idx, mi);
-	for (i = o.ind + 1; i < argc; ++i)
-		mp_map_file(mi, argv[i], &mo, n_threads);
+	for (i = o.ind + 1; i < argc; ++i) {
+		int32_t res = mp_map_file(mi, argv[i], &mo, n_threads);
+		if (res != 0) {
+			fprintf(stderr, "[M::%s] ERROR during mapping %s (check files exists and is amino acid fasta)\n", __func__, argv[i]);
+			return 1;
+		}
+	}
 	mp_idx_destroy(mi);
 
 	if (mp_verbose >= 3) {


### PR DESCRIPTION
Hi Heng,

Thanks for yet another brilliant tool!

This patch reports errors mapping amino acid files to the reference. AFAICT, the only non-zero exit code of mp_map_file() is for errors opening the faa file(s). I hit this due to a stupid error on my part: giving `query.faa.gz` when only `query.faa` existed on disk. Miniprot ran fine but of course gave an empty gff. Now, the user should at least get a warning and a non-zero exit code in case of stupidity :)

Best,
Kevin