### PR TITLE
Pgap 9185 gencode 1

### DIFF
--- a/main.c
+++ b/main.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 	mp_idxopt_t io;
 	mp_idx_t *mi;
 	char *fn_idx = 0;
-
+	mp_start(0);
 	mp_mapopt_init(&mo);
 	mp_idxopt_init(&io);
 	while ((c = ketopt(&o, argc, argv, 1, "k:M:L:s:l:b:t:d:c:n:m:K:p:N:SAO:E:J:C:F:G:e:uB:P:w:j:g:I", long_options)) >= 0) {
@@ -171,13 +171,15 @@ int main(int argc, char *argv[])
     if(mo.gen_code>0) {
         codon_type = mo.gen_code-1;
     }
-	mp_start(codon_type);
+    /*
+        We have to call ns_make_tables again now.
+    */
+    ns_make_tables(codon_type);
 	if (mp_mapopt_check(&mo) < 0) return 1;
 	if (argc - o.ind == 0 || (argc - o.ind == 1 && fn_idx == 0)) {
 		print_usage(stderr, &io, &mo, n_threads);
 		return 1;
 	}
-
 	mi = mp_idx_load(argv[o.ind], &io, n_threads);
 	if (mi == 0) {
 		if (mp_verbose >= 1)

--- a/main.c
+++ b/main.c
@@ -27,7 +27,7 @@ static ko_longopt_t long_options[] = {
 	{ "dbg-aflt",        ko_no_argument,       504 },
 	{ "dbg-anchor",      ko_no_argument,       505 },
 	{ "dbg-chain",       ko_no_argument,       506 },
-    { "gen-code",        ko_required_argument, 601 },
+    { "gc",        ko_required_argument, 601 },
 	{ 0, 0, 0 }
 };
 
@@ -79,6 +79,7 @@ static void print_usage(FILE *fp, const mp_idxopt_t *io, const mp_mapopt_t *mo, 
 	fprintf(fp, "    -C FLOAT     weight of splice penalty; 0 to ignore splice signals [%g]\n", mo->sp_scale);
 	fprintf(fp, "    -B INT       bonus score for alignment reaching query ends [%d]\n", mo->end_bonus);
 	fprintf(fp, "    -j INT       splice model: 2=mammal, 1=general, 0=none (see manual) [%d]\n", mo->sp_model);
+	fprintf(fp, "    --gc=INT     genetic code: 0,1=standard, 4=mold [%d]\n", mo->gen_code);
 	fprintf(fp, "  Input/output:\n");
 	fprintf(fp, "    -t INT       number of threads [%d]\n", n_threads);
 	fprintf(fp, "    --gff        output in the GFF3 format\n");
@@ -156,7 +157,7 @@ int main(int argc, char *argv[])
 		else if (c == 504) mp_dbg_flag |= MP_DBG_MORE_DP; // --dbg-aflt
 		else if (c == 505) mp_dbg_flag |= MP_DBG_ANCHOR; // --dbg-anchor
 		else if (c == 506) mp_dbg_flag |= MP_DBG_CHAIN; // --dbg-chain
-		else if (c == 601) mo.gen_code = atoi(o.arg); // --gen-code
+		else if (c == 601) mo.gen_code = atoi(o.arg); // --gc
 		else if (c == 's') {
 			fprintf(stderr, "Option '-s' is deprecated.\n");
 		} else if (c == 401) {

--- a/main.c
+++ b/main.c
@@ -27,6 +27,7 @@ static ko_longopt_t long_options[] = {
 	{ "dbg-aflt",        ko_no_argument,       504 },
 	{ "dbg-anchor",      ko_no_argument,       505 },
 	{ "dbg-chain",       ko_no_argument,       506 },
+    { "gen-code",        ko_required_argument, 601 },
 	{ 0, 0, 0 }
 };
 
@@ -101,7 +102,6 @@ int main(int argc, char *argv[])
 	mp_idx_t *mi;
 	char *fn_idx = 0;
 
-	mp_start();
 	mp_mapopt_init(&mo);
 	mp_idxopt_init(&io);
 	while ((c = ketopt(&o, argc, argv, 1, "k:M:L:s:l:b:t:d:c:n:m:K:p:N:SAO:E:J:C:F:G:e:uB:P:w:j:g:I", long_options)) >= 0) {
@@ -156,6 +156,7 @@ int main(int argc, char *argv[])
 		else if (c == 504) mp_dbg_flag |= MP_DBG_MORE_DP; // --dbg-aflt
 		else if (c == 505) mp_dbg_flag |= MP_DBG_ANCHOR; // --dbg-anchor
 		else if (c == 506) mp_dbg_flag |= MP_DBG_CHAIN; // --dbg-chain
+		else if (c == 601) mo.gen_code = atoi(o.arg); // --gen-code
 		else if (c == 's') {
 			fprintf(stderr, "Option '-s' is deprecated.\n");
 		} else if (c == 401) {
@@ -165,6 +166,11 @@ int main(int argc, char *argv[])
 			fprintf(stderr, "[WARNING]\033[1;31m unrecognized option: %s\033[0m\n", argv[o.i-1]);
 		}
 	}
+    int codon_type = 0;
+    if(mo.gen_code>0) {
+        codon_type = mo.gen_code-1;
+    }
+	mp_start(codon_type);
 	if (mp_mapopt_check(&mo) < 0) return 1;
 	if (argc - o.ind == 0 || (argc - o.ind == 1 && fn_idx == 0)) {
 		print_usage(stderr, &io, &mo, n_threads);

--- a/miniprot.h
+++ b/miniprot.h
@@ -23,6 +23,7 @@
 #define MP_BLOCK_BONUS    2
 
 #define MP_CODON_STD 0
+#define MP_CODON_MOLD 3
 #define MP_IDX_MAGIC "MPI\2"
 
 #ifdef __cplusplus
@@ -72,6 +73,7 @@ typedef struct {
 	int32_t max_intron_flank;
 	const char *gff_prefix;
 	int8_t mat[484];
+    int32_t gen_code;
 } mp_mapopt_t;
 
 typedef struct {
@@ -141,7 +143,7 @@ extern char *ns_tab_nt_i2c, *ns_tab_aa_i2c;
 extern uint8_t ns_tab_a2r[22], ns_tab_nt4[256], ns_tab_aa20[256], ns_tab_aa13[256];
 extern uint8_t ns_tab_codon[64], ns_tab_codon13[64];
 
-void mp_start(void);
+void mp_start(int codon_type);
 
 void mp_idxopt_init(mp_idxopt_t *io);
 void mp_mapopt_init(mp_mapopt_t *mo);

--- a/misc.c
+++ b/misc.c
@@ -9,9 +9,9 @@ KRADIX_SORT_INIT(mp128x, mp128_t, sort_key_128x, 8)
 
 int32_t mp_verbose = 3, mp_dbg_flag = 0;
 
-void mp_start(void)
+void mp_start(int codon_type)
 {
-	ns_make_tables(MP_CODON_STD);
+	ns_make_tables(codon_type);
 	mp_realtime();
 }
 

--- a/nasw-tab.c
+++ b/nasw-tab.c
@@ -11,10 +11,10 @@ char *ns_tab_aa_i2c = "ARNDCQEGHILKMFPSTWYV*X";
 uint8_t ns_tab_a2r[22] = { 0, 2, 4, 4, 6, 5, 5, 8, 3, 10, 11, 2, 11, 12, 7, 1, 1, 13, 12, 10, 14, 15 };
 						// A  R  N  D  C  Q  E  G  H   I   L  K   M   F  P  S  T   W   Y   V   *   X
 
-char *ns_tab_codon_std = "KNKNTTTTRSRSIIMIQHQHPPPPRRRRLLLLEDEDAAAAGGGGVVVV*Y*YSSSS*CWCLFLFX";
-					   // 01234567890123456789012345678901234567890123456789012345678901234
-					   // KKNNRRSSTTTTIMIIEEDDGGGGAAAAVVVVQQHHRRRRPPPPLLLL**YY*WCCSSSSLLFFX <- this is the AGCT order
-
+char *ns_tab_codon_std =  "KNKNTTTTRSRSIIMIQHQHPPPPRRRRLLLLEDEDAAAAGGGGVVVV*Y*YSSSS*CWCLFLFX";
+					   //  01234567890123456789012345678901234567890123456789012345678901234
+					   //  KKNNRRSSTTTTIMIIEEDDGGGGAAAAVVVVQQHHRRRRPPPPLLLL**YY*WCCSSSSLLFFX <- this is the AGCT order
+char *ns_tab_codon_mold = "KNKNTTTTRSRSIIMIQHQHPPPPRRRRLLLLEDEDAAAAGGGGVVVV*Y*YSSSSWCWCLFLFX";
 uint8_t ns_tab_nt4[256], ns_tab_aa20[256], ns_tab_aa13[256], ns_tab_codon[64], ns_tab_codon13[64];
 
 int8_t ns_mat_blosum62[484] = { // 484 = 22*22
@@ -57,7 +57,12 @@ void ns_make_tables(int codon_type)
 	for (p = ns_tab_aa_i2c; *p; ++p)
 		ns_tab_aa13[p - ns_tab_aa_i2c] = ns_tab_aa13[(uint8_t)toupper(*p)] = ns_tab_aa13[(uint8_t)tolower(*p)] = ns_tab_a2r[p - ns_tab_aa_i2c];
 	for (i = 0; i < 64; ++i) {
-		ns_tab_codon[i] = ns_tab_aa20[(uint8_t)ns_tab_codon_std[i]];
+        if (codon_type == 0) {
+            ns_tab_codon[i] = ns_tab_aa20[(uint8_t)ns_tab_codon_std[i]];
+        }
+        else if (codon_type==3) { /* THE MOLD genetic code 4 */
+            ns_tab_codon[i] = ns_tab_aa20[(uint8_t)ns_tab_codon_mold[i]];
+        }
 		ns_tab_codon13[i] = ns_tab_a2r[ns_tab_codon[i]];
 	}
 }


### PR DESCRIPTION
The theme of this pull request - ability to run miniprot with more genetic codes, namely, in addition to "standard" ("1" in NCBI classification of gencodes), which matches in terms of stop codons and middle-of-the-sequence as popular prokaryotic code "11", the "Mold" genetic code ("4" in NCBI classification) - a lot of prokaryotic organisms use this code. 

We found that using correct code "4" for these organism set produces improvements in annotation. 

Thus - the nature of the request. 

Thank you for your consideration!

